### PR TITLE
fix: add missing is_decode parameter to FP4 KV pool set_kv_buffer

### DIFF
--- a/sglang-research/python/sglang/srt/mem_cache/memory_pool.py
+++ b/sglang-research/python/sglang/srt/mem_cache/memory_pool.py
@@ -1501,6 +1501,7 @@ class MHATokenToKVPoolFP4(MHATokenToKVPool):
         k_scale: Optional[float] = None,
         v_scale: Optional[float] = None,
         layer_id_override: Optional[int] = None,
+        is_decode: bool = False,
     ):
         from sglang.srt.model_executor.cuda_graph_runner import get_is_capture_mode
 


### PR DESCRIPTION
## Summary

Add the missing `is_decode` parameter to `MHATokenToKVPoolFP4.set_kv_buffer()`.

The Triton decode path may call:

```python
set_kv_buffer(..., is_decode=True)
```

but the FP4 implementation currently does not accept this keyword argument, causing FP4 decode requests to fail with:

```text
TypeError: MHATokenToKVPoolFP4.set_kv_buffer() got an unexpected keyword argument 'is_decode'
```

This change aligns the FP4 method signature with the base MHA KV pool implementation and restores compatibility with the shared decode caller.

Fixes #5 
